### PR TITLE
chore: update versions of Node.js tested

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,9 +5,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   release:
     name: Release

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "email": "rtrott@gmail.com"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "scripts": {
     "test": "standard && c8 --check-coverage --lines 100 --functions 100 --branches 100 ava test.js"

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# cheesy-metal [![Build Status](https://travis-ci.org/Trott/cheesy-metal.svg?branch=master)](https://travis-ci.org/Trott/cheesy-metal)
+# cheesy-metal
 
 > Cheesy metal band name generator
 


### PR DESCRIPTION
BREAKING CHANGE: Dropping support for Node.js earlier than 12.x.